### PR TITLE
adc1_get_voltage() is deprecated.

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -91,7 +91,7 @@ mrb_esp32_gpio_analog_read(mrb_state *mrb, mrb_value self) {
 
   adc1_config_channel_atten(mrb_fixnum(ch), ADC_ATTEN_11db);
 
-  return mrb_fixnum_value(adc1_get_voltage(mrb_fixnum(ch)));
+  return mrb_fixnum_value(adc1_get_raw(mrb_fixnum(ch)));
 }
 
 static mrb_value


### PR DESCRIPTION
adc1_get_voltage() has already been deprecated, causing the following build errors.

```
CC    build/repos/esp32/mruby-esp32-gpio/src/gpio.c -> build/esp32/mrbgems/mruby-esp32-gpio/src/gpio.o
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/build/repos/esp32/mruby-esp32-gpio/src/gpio.c: In function 'mrb_esp32_gpio_analog_read':
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/build/repos/esp32/mruby-esp32-gpio/src/gpio.c:94:27: error: implicit declaration of function 'adc1_get_voltagadc1_get_voltage() has already been deprecated, causing the following build errors.e'; did you mean 'adc1_get_raw'? [-Werror=implicit-function-declaration]
   return mrb_fixnum_value(adc1_get_voltage(mrb_fixnum(ch)));
                           ^~~~~~~~~~~~~~~~
                           adc1_get_raw
cc1: some warnings being treated as errors
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/build/repos/esp32/mruby-esp32-gpio/src/gpio.c: In function 'mrb_esp32_gpio_analog_read':
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/build/repos/esp32/mruby-esp32-gpio/src/gpio.c:94:27: error: implicit declaration of function 'adc1_get_voltage'; did you mean 'adc1_get_raw'? [-Werror=implicit-function-declaration]
   return mrb_fixnum_value(adc1_get_voltage(mrb_fixnum(ch)));
                           ^~~~~~~~~~~~~~~~
                           adc1_get_raw
cc1: some warnings being treated as errors
rake aborted!
Command failed with status (1): [xtensa-esp32-elf-gcc -std=gnu99 -std=gnu99...]
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:39:in `_run'
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:44:in `rescue in _run'
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:40:in `_run'
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:90:in `run'
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:113:in `block (2 levels) in define_rules'

Caused by:
Command failed with status (1): [xtensa-esp32-elf-gcc -std=gnu99 -std=gnu99...]
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:41:in `_run'
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:90:in `run'
/Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/lib/mruby/build/command.rb:113:in `block (2 levels) in define_rules'
Tasks: TOP => default => all => /Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/build/esp32/lib/libmruby.a => /Users/user/esp/mruby-esp32-app-mirb/components/mruby/mruby/build/esp32/mrbgems/mruby-esp32-gpio/src/gpio.o
(See full trace by running task with --trace)
make[2]: *** [all] Error 1
make[1]: *** [build] Error 2
make: *** [component-mruby-build] Error 2
```

adc1_get_voltage() can be replaced by adc1_get_raw(), and so can the I/F.

https://github.com/espressif/esp-idf/blob/13978c955653c163c598912e9db1a2383fb7d36e/components/driver/adc_common.c#L502

Fixed to use adc1_get_raw() and confirmed that the build passes.

